### PR TITLE
Remove need to do select(null) before selecting single field

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -221,7 +221,7 @@ abstract class BaseQuery implements IteratorAggregate {
 		return trim($query);
 	}
 
-	private function clauseNotEmpty($clause) {
+	protected function clauseNotEmpty($clause) {
 		if ($this->clauses[$clause]) {
 			return (boolean) count($this->statements[$clause]);
 		} else {

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -41,12 +41,24 @@ class SelectQuery extends CommonQuery implements Countable {
 		$this->statements['FROM'] = $from;
 		$this->joins[] = $this->fromAlias;
 	}
-	
+
         protected function clauseNotEmpty($clause) {
             $return = parent::clauseNotEmpty($clause);
-            if (!$return && $clause == "SELECT") {
-                $this->statements['SELECT'][] = $this->fromAlias . '.*';
-                $return = true;
+            if ($clause == "SELECT") {
+                if (!empty($this->statements['JOIN']) && $return) {
+                    $return = false;
+                    foreach($this->statements['SELECT'] as $select) {
+                        $parts = explode(".", $select);
+                        $table = $parts['0'];
+                        if ($table == $this->statements['FROM']) {
+                            $return = true;
+                        }
+                    }
+                }
+                if (!$return) {
+                    array_unshift($this->statements['SELECT'], $this->fromAlias.'.*');
+                    $return = true;
+                }
             }
             return $return;
         }

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -49,7 +49,7 @@ class SelectQuery extends CommonQuery implements Countable {
 				$data = array($this->fromAlias, false);
 				$res = explode(",", $select);
 				array_walk($res, function(&$res, $key, &$data) {
-					$res = rtrim(trim($res), '() _a..zA..Z');
+					$res = rtrim(trim($res), '() _a..zA..Z0..9');
 					if (preg_match('/('.$data[0][0].'(?:[\`\"])?\.)|((?<!\.)\*)/', $res) || empty($res)) {
 						$data[0][1] = true;
 					}

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -44,15 +44,20 @@ class SelectQuery extends CommonQuery implements Countable {
 
 	protected function clauseNotEmpty($clause) {
 		$return = parent::clauseNotEmpty($clause);
-		if (!empty($this->statements['JOIN']) && $return && $clause == "SELECT") {
-			$return = false;
+		if ($clause == "SELECT" && $return) {
 			foreach($this->statements['SELECT'] as $select) {
-				if (preg_match('/'.$this->fromAlias.'(?=\.)/', $select)) {
-					$return = true;
-				}
+				$data = array($this->fromAlias, false);
+				$res = explode(",", $select);
+				array_walk($res, function(&$res, $key, &$data) {
+					$res = rtrim(trim($res), '() _a..zA..Z');
+					if (preg_match('/('.$data[0][0].'(?:[\`\"])?\.)/', $res) || empty($res)) {
+						$data[0][1] = true;
+					}
+				}, array(&$data));
+				$return = $data[1];
 			}
 		}
-		if (!$return && $clause == "SELECT") {
+		if ($clause == "SELECT" && !$return) {
 			array_unshift($this->statements['SELECT'], $this->fromAlias.'.*');
 			$return = true;
 		}

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -42,26 +42,22 @@ class SelectQuery extends CommonQuery implements Countable {
 		$this->joins[] = $this->fromAlias;
 	}
 
-        protected function clauseNotEmpty($clause) {
-            $return = parent::clauseNotEmpty($clause);
-            if ($clause == "SELECT") {
-                if (!empty($this->statements['JOIN']) && $return) {
-                    $return = false;
-                    foreach($this->statements['SELECT'] as $select) {
-                        $parts = explode(".", $select);
-                        $table = $parts['0'];
-                        if ($table == $this->statements['FROM']) {
-                            $return = true;
-                        }
-                    }
-                }
-                if (!$return) {
-                    array_unshift($this->statements['SELECT'], $this->fromAlias.'.*');
-                    $return = true;
-                }
-            }
-            return $return;
-        }
+	protected function clauseNotEmpty($clause) {
+		$return = parent::clauseNotEmpty($clause);
+		if (!empty($this->statements['JOIN']) && $return && $clause == "SELECT") {
+			$return = false;
+			foreach($this->statements['SELECT'] as $select) {
+				if (preg_match('/'.$this->fromAlias.'(?=\.)/', $select)) {
+					$return = true;
+				}
+			}
+		}
+		if (!$return && $clause == "SELECT") {
+			array_unshift($this->statements['SELECT'], $this->fromAlias.'.*');
+			$return = true;
+		}
+		return $return;
+	}
 
 	/** Return table name from FROM clause
 	 * @internal

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -39,9 +39,17 @@ class SelectQuery extends CommonQuery implements Countable {
 		$this->fromAlias = end($fromParts);
 
 		$this->statements['FROM'] = $from;
-		$this->statements['SELECT'][] = $this->fromAlias . '.*';
 		$this->joins[] = $this->fromAlias;
 	}
+	
+        protected function clauseNotEmpty($clause) {
+            $return = parent::clauseNotEmpty($clause);
+            if (!$return && $clause == "SELECT") {
+                $this->statements['SELECT'][] = $this->fromAlias . '.*';
+                $return = true;
+            }
+            return $return;
+        }
 
 	/** Return table name from FROM clause
 	 * @internal

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -50,7 +50,7 @@ class SelectQuery extends CommonQuery implements Countable {
 				$res = explode(",", $select);
 				array_walk($res, function(&$res, $key, &$data) {
 					$res = rtrim(trim($res), '() _a..zA..Z');
-					if (preg_match('/('.$data[0][0].'(?:[\`\"])?\.)/', $res) || empty($res)) {
+					if (preg_match('/('.$data[0][0].'(?:[\`\"])?\.)|((?<!\.)\*)/', $res) || empty($res)) {
 						$data[0][1] = true;
 					}
 				}, array(&$data));


### PR DESCRIPTION
This change will allow you to do $fpdo->from("myTable")->select("fieldName"); without adding select(null) first. It will still default back to "myTable.*" if the select clause is empty.

Any thoughts, did I perhaps break something else by doing this - or is there some reason why this could be a bad idea that I've missed?