### PR TITLE
allow GetResult() to obtain the original statement on error instead of

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -116,14 +116,15 @@ abstract class BaseQuery implements IteratorAggregate {
 		$time = microtime(true);
 		if ($result && $result->execute($parameters)) {
 			$this->time = microtime(true) - $time;
+			$result2 = $result;
 		} else {
-			$result = false;
+			$result2 = false;
 		}
 
 		$this->result = $result;
 		$this->debugger();
 
-		return $result;
+		return $result2;
 	}
 
 	private function debugger() {


### PR DESCRIPTION
Close #61 
Very small patch that allow to retrieve the latest PDOStatement used during the latest query.
This way the backward compatibility is keeped (it still returns false)
and its possibile to retrieve, finally, the error message this way:

```
$rec = $query->fetchAll();
if ($rec===FALSE) {
   $res = $query->getResult();
   print_r( $res->errorInfo() );
}
```