### PR TITLE
Added ability to specify query error handler

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -117,6 +117,7 @@ abstract class BaseQuery implements IteratorAggregate {
 		if ($result && $result->execute($parameters)) {
 			$this->time = microtime(true) - $time;
 		} else {
+			$this->errorHandler($result);
 			$result = false;
 		}
 
@@ -149,6 +150,16 @@ abstract class BaseQuery implements IteratorAggregate {
 				fwrite(STDERR, "# $backtrace[file]:$backtrace[line] ($time; rows = $rows)\n$debug\n\n");
 			} else {
 				call_user_func($this->fpdo->debug, $this);
+			}
+		}
+	}
+
+	private function errorHandler(PDO $result) {
+		if ($this->fpdo->errorHandler) {
+			if (!is_callable($this->fpdo->errorHandler)) {
+				// default behavior is to ignore the error
+			} else {
+				call_user_func($this->fpdo->errorHandler, $this, $result);
 			}
 		}
 	}

--- a/FluentPDO/FluentPDO.php
+++ b/FluentPDO/FluentPDO.php
@@ -28,6 +28,9 @@ class FluentPDO {
 	/** @var boolean|callback */
 	public $debug;
 
+	/** @var boolean|callback */
+	public $errorHandler;
+
 	function __construct(PDO $pdo, FluentStructure $structure = null) {
 		$this->pdo = $pdo;
 		if (!$structure) {


### PR DESCRIPTION
The default behavior currently is to ignore all errors. This PR makes it possible to specify your own custom error handler without changing that default behavior.

Example:

    $fpdo = new FluentPDO($pdo);
    $fpdo->errorHandler = function (BaseQuery $query, PDO $result) {
        print_r($query->getQuery());
        print_r($result->errorInfo());
    };