### PR TITLE
Fix logic error in from() when primary key evaluates to false

### DIFF
--- a/FluentPDO/FluentPDO.php
+++ b/FluentPDO/FluentPDO.php
@@ -43,7 +43,7 @@ class FluentPDO {
 	 */
 	public function from($table, $primaryKey = null) {
 		$query = new SelectQuery($this, $table);
-		if ($primaryKey) {
+		if (!is_null($primaryKey)) {
 			$tableTable = $query->getFromTable();
 			$tableAlias = $query->getFromAlias();
 			$primaryKeyName = $this->structure->getPrimaryKey($tableTable);


### PR DESCRIPTION
When called like `$fpdo->from('table', 0)` or with an empty string instead
of zero (which can be caused by a bad input check, or any other
programmer error), the resulting query is without any where condition.

The behavior I expected was that this is a true shortcut to 
`$fpdo->from('table')->where('id', 0)` and would work correctly with
int(0) or an empty string, so that the executed query returns no
results.

Instead the query returns all rows, unless there are additional where() 
conditions after the bogus `from()`.