### PR TITLE
Parametrize all queries of InsertQuery class

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -229,7 +229,7 @@ abstract class BaseQuery implements IteratorAggregate {
 		}
 	}
 
-	private function buildParameters() {
+	protected function buildParameters() {
 		$parameters = array();
 		foreach ($this->parameters as $clauses) {
 			if (is_array($clauses)) {

--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -108,24 +108,25 @@ class InsertQuery extends BaseQuery {
 	}
 
 	/**
-	 * Recursively removes all FluentLiteral instances from the argument
+	 * Removes all FluentLiteral instances from the argument
 	 * since they are not to be used as PDO parameters but rather injected directly into the query
 	 *
 	 * @param $statements
 	 * @return array
 	 */
-	protected function filterLiterals($statements) {
-        $self = $this;
-		return array_map(function($item) use($self) {
-			if (is_array($item)) {
-                return call_user_func(array($self, 'filterLiterals'), $item);
-			}
+    protected function filterLiterals($statements) {
+        $f = function($item){
+            return !$item instanceof FluentLiteral;
+        };
 
-			return $item;
-		}, array_filter($statements, function($item){
-			return !$item instanceof FluentLiteral;
-		}));
-	}
+        return array_map(function($item) use($f) {
+            if (is_array($item)) {
+                return array_filter($item, $f);
+            }
+
+            return $item;
+        }, array_filter($statements, $f));
+    }
 
 	protected function buildParameters(){
 		$this->parameters = array_merge(

--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -95,12 +95,10 @@ class InsertQuery extends BaseQuery {
 	protected function getClauseValues() {
 		$valuesArray = array();
 		foreach ($this->statements['VALUES'] as $rows) {
-			$placeholders = array_map(function($item){
-				// literals should not be parametrized.
-				// They are commonly used to call engine functions or literals.
-				// Eg: NOW(), CURRENT_TIMESTAMP etc
-				return $this->parameterGetValue($item);
-			}, $rows);
+            // literals should not be parametrized.
+            // They are commonly used to call engine functions or literals.
+            // Eg: NOW(), CURRENT_TIMESTAMP etc
+			$placeholders = array_map(array($this, 'parameterGetValue'), $rows);
 			$valuesArray[] = '(' . implode(', ', $placeholders) . ')';
 		}
 
@@ -119,7 +117,7 @@ class InsertQuery extends BaseQuery {
 	protected function filterLiterals($statements) {
 		return array_map(function($item) {
 			if (is_array($item)) {
-				return $this->filterLiterals($item);
+                return call_user_func(array($this, 'filterLiterals'), $item);
 			}
 
 			return $item;

--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -88,19 +88,19 @@ class InsertQuery extends BaseQuery {
 		return 'INSERT' . ($this->ignore ? " IGNORE" : '') . ($this->delayed ? " DELAYED" : '') . ' INTO ' . $this->statements['INSERT INTO'];
 	}
 
-    protected function parameterGetValue($param) {
-        return $param instanceof FluentLiteral ? (string)$param : '?';
-    }
+	protected function parameterGetValue($param) {
+		return $param instanceof FluentLiteral ? (string)$param : '?';
+	}
 
 	protected function getClauseValues() {
 		$valuesArray = array();
 		foreach ($this->statements['VALUES'] as $rows) {
 			$placeholders = array_map(function($item){
-                // literals should not be parametrized.
-                // They are commonly used to call engine functions or literals.
-                // Eg: NOW(), CURRENT_TIMESTAMP etc
-                return $this->parameterGetValue($item);
-            }, $rows);
+				// literals should not be parametrized.
+				// They are commonly used to call engine functions or literals.
+				// Eg: NOW(), CURRENT_TIMESTAMP etc
+				return $this->parameterGetValue($item);
+			}, $rows);
 			$valuesArray[] = '(' . implode(', ', $placeholders) . ')';
 		}
 
@@ -109,33 +109,33 @@ class InsertQuery extends BaseQuery {
 		return " ($columns) VALUES $values";
 	}
 
-    /**
-     * Recursively removes all FluentLiteral instances from the argument
-     * since they are not to be used as PDO parameters but rather injected directly into the query
-     *
-     * @param $statements
-     * @return array
-     */
-    protected function filterLiterals($statements) {
-        return array_map(function($item) {
-            if (is_array($item)) {
-                return $this->filterLiterals($item);
-            }
+	/**
+	 * Recursively removes all FluentLiteral instances from the argument
+	 * since they are not to be used as PDO parameters but rather injected directly into the query
+	 *
+	 * @param $statements
+	 * @return array
+	 */
+	protected function filterLiterals($statements) {
+		return array_map(function($item) {
+			if (is_array($item)) {
+				return $this->filterLiterals($item);
+			}
 
-            return $item;
-        }, array_filter($statements, function($item){
-            return !$item instanceof FluentLiteral;
-        }));
-    }
+			return $item;
+		}, array_filter($statements, function($item){
+			return !$item instanceof FluentLiteral;
+		}));
+	}
 
-    protected function buildParameters(){
-        $this->parameters = array_merge(
-            $this->filterLiterals($this->statements['VALUES']),
-            $this->filterLiterals($this->statements['ON DUPLICATE KEY UPDATE'])
-        );
+	protected function buildParameters(){
+		$this->parameters = array_merge(
+			$this->filterLiterals($this->statements['VALUES']),
+			$this->filterLiterals($this->statements['ON DUPLICATE KEY UPDATE'])
+		);
 
-        return parent::buildParameters();
-    }
+		return parent::buildParameters();
+	}
 
 	protected function getClauseOnDuplicateKeyUpdate() {
 		$result = array();

--- a/tests/32-insert.phpt
+++ b/tests/32-insert.phpt
@@ -6,17 +6,24 @@ include_once dirname(__FILE__) . "/connect.inc.php";
 /* @var $fpdo FluentPDO */
 
 $query = $fpdo->insertInto('article',
-		array(
-			'user_id' => 1,
-			'title' => 'new title',
-			'content' => 'new content'
-		));
+        array(
+            'user_id' => 1,
+            'title' => 'new title',
+            'content' => 'new content'
+        ));
 
 echo $query->getQuery() . "\n";
+print_r($query->getParameters());
 $lastInsert = $query->execute();
 
 $pdo->query('DELETE FROM article WHERE id > 3')->execute();
 ?>
 --EXPECTF--
 INSERT INTO article (user_id, title, content)
-VALUES (1, 'new title', 'new content')
+VALUES (?, ?, ?)
+Array
+(
+    [0] => 1
+    [1] => new title
+    [2] => new content
+)

--- a/tests/33-insert-update.phpt
+++ b/tests/33-insert-update.phpt
@@ -8,10 +8,11 @@ include_once dirname(__FILE__) . "/connect.inc.php";
 $query = $fpdo->insertInto('article', array('id' => 1))
 		->onDuplicateKeyUpdate(array(
 			'title' => 'article 1b',
-			'content' => 'content 1b',
+			'content' => new FluentLiteral('abs(-1)') // let's update with a literal and a parameter value
 		));
 
 echo $query->getQuery() . "\n";
+print_r($query->getParameters());
 echo 'last_inserted_id = ' . $query->execute() . "\n";
 $q = $fpdo->from('article', 1)->fetch();
 print_r($q);
@@ -26,8 +27,13 @@ print_r($q);
 ?>
 --EXPECTF--
 INSERT INTO article (id)
-VALUES (1)
-ON DUPLICATE KEY UPDATE title = 'article 1b', content = 'content 1b'
+VALUES (?)
+ON DUPLICATE KEY UPDATE title = ?, content = abs(-1)
+Array
+(
+    [0] => 1
+    [1] => article 1b
+)
 last_inserted_id = 1
 Array
 (
@@ -35,7 +41,7 @@ Array
     [user_id] => 1
     [published_at] => 2011-12-10 12:10:00
     [title] => article 1b
-    [content] => content 1b
+    [content] => 1
 )
 last_inserted_id = 1
 Array

--- a/tests/34-insert-ignore.phpt
+++ b/tests/34-insert-ignore.phpt
@@ -13,8 +13,14 @@ $query = $fpdo->insertInto('article',
 		))->ignore();
 
 echo $query->getQuery() . "\n";
-
+print_r($query->getParameters());
 ?>
 --EXPECTF--
 INSERT IGNORE INTO article (user_id, title, content)
-VALUES (1, 'new title', 'new content')
+VALUES (?, ?, ?)
+Array
+(
+    [0] => 1
+    [1] => new title
+    [2] => new content
+)

--- a/tests/35-insert-with-literal.phpt
+++ b/tests/35-insert-with-literal.phpt
@@ -14,8 +14,15 @@ $query = $fpdo->insertInto('article',
 		));
 
 echo $query->getQuery() . "\n";
+print_r($query->getParameters());
 
 ?>
 --EXPECTF--
 INSERT INTO article (user_id, updated_at, title, content)
-VALUES (1, NOW(), 'new title', 'new content')
+VALUES (?, NOW(), ?, ?)
+Array
+(
+    [0] => 1
+    [1] => new title
+    [2] => new content
+)

--- a/tests/62-insert-delayed.phpt
+++ b/tests/62-insert-delayed.phpt
@@ -13,8 +13,15 @@ $query = $fpdo->insertInto('article',
 		))->delayed();
 
 echo $query->getQuery() . "\n";
+print_r($query->getParameters());
 
 ?>
 --EXPECTF--
 INSERT DELAYED INTO article (user_id, title, content)
-VALUES (1, 'new title', 'new content')
+VALUES (?, ?, ?)
+Array
+(
+    [0] => 1
+    [1] => new title
+    [2] => new content
+)


### PR DESCRIPTION
Right now, the `InsertQuery` class rather than parametrizing quotes - injects all the parameters to the created query. For obvious reasons this is suboptimal.

This PR fixes that by making the aforementioned class use positional placeholders. Also it enables this library to: work with ODBC (which does not support the `quote` method), inserting Unicode data to Microsoft SQL Server (which was impossible until now) and possibly other engines that do not support `quote` or have odd behaviour with Unicode data à la [SQL Server](https://support.microsoft.com/en-us/kb/239530).

Tests are also updated to reflect the changes.