### PR TITLE
Add array_shift in buildQuery in CommonQuery.php

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -190,6 +190,8 @@ abstract class CommonQuery extends BaseQuery {
 	protected function buildQuery() {
 		# first create extra join from statements with columns with referenced tables
 		$statementsWithReferences = array('WHERE', 'SELECT', 'GROUP BY', 'ORDER BY');
+		if( count( $this->statements['SELECT'] ) > 1 )
+			array_shift($this->statements['SELECT']);
 		foreach ($statementsWithReferences as $clause) {
 			if (array_key_exists($clause, $this->statements)) {
 				$this->statements[$clause] = array_map(array($this, 'createUndefinedJoins'), $this->statements[$clause]);


### PR DESCRIPTION
This would not have to use select(null) before any other select.

This:
$ fpdo->from('users')->select(null)->select('name');

becomes this:
$ fpdo->from('users')->select('name');

Regards from mexico. I used google translate, sorry for the translation.