### PR TITLE
Properties from private to protected

### DIFF
--- a/FluentPDO/FluentPDO.php
+++ b/FluentPDO/FluentPDO.php
@@ -23,7 +23,7 @@ include_once 'DeleteQuery.php';
 
 class FluentPDO {
 
-	private $pdo, $structure;
+	protected $pdo, $structure;
 
 	/** @var boolean|callback */
 	public $debug;


### PR DESCRIPTION
FluentPDO is a lib and if you have to extend it you need protected properties. Nothing speaks for private properties in this case.