### PR TITLE
Fixes a bug where the "WHERE" clause would not correctly detect a valid column name passed on the condition;

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -46,7 +46,13 @@ abstract class CommonQuery extends BaseQuery {
 		if (count($args) == 1) {
 			return $this->addStatement('WHERE', $condition);
 		}
-		if (count($args) == 2 && preg_match('~^(NOT )?`?[a-z_:][a-z0-9_.:]*`?$~i', $condition)) {
+
+		// check that there are 2 arguments, a condition and a parameter value
+		// if the condition contains comparison operator simply add them
+		// since its up to the user if it's valid sql or not
+		// Otherwise we're probably with just an identifier. So lets
+		// construct a new condition based on the passed parameter value.
+		if (count($args) == 2 && !preg_match('~[>|>=|<|<=|=|!=|<>|<!|!>]~i', $condition)) {
 			# condition is column only
 			if (is_null($parameters)) {
 				return $this->addStatement('WHERE', "$condition is NULL");

--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -48,11 +48,11 @@ abstract class CommonQuery extends BaseQuery {
 		}
 
 		// check that there are 2 arguments, a condition and a parameter value
-		// if the condition contains comparison operator simply add them
+		// if the condition contains a parameter simply add them
 		// since its up to the user if it's valid sql or not
 		// Otherwise we're probably with just an identifier. So lets
 		// construct a new condition based on the passed parameter value.
-		if (count($args) == 2 && !preg_match('~[>|>=|<|<=|=|!=|<>|<!|!>]~i', $condition)) {
+		if (count($args) == 2 && !preg_match('~(\?|:\w+)~i', $condition)) {
 			# condition is column only
 			if (is_null($parameters)) {
 				return $this->addStatement('WHERE', "$condition is NULL");

--- a/tests/63-update-where.phpt
+++ b/tests/63-update-where.phpt
@@ -1,0 +1,44 @@
+--TEST--
+update where
+--FILE--
+<?php
+include_once dirname(__FILE__) . "/connect.inc.php";
+/* @var $fpdo FluentPDO */
+
+$query = $fpdo->update('users')
+    ->set("`users`.`active`", 1)
+    ->where("`confirm`.`key`", 123)
+    ->where("`users`.`email`", 123);
+
+
+echo $query->getQuery() . "\n";
+print_r($query->getParameters());
+$query = $fpdo->update('users')
+    ->set("[users].[active]", 1)
+    ->where("[confirm].[key]", 123)
+    ->where("[users].[email]", 123);
+
+
+echo $query->getQuery() . "\n";
+print_r($query->getParameters());
+
+?>
+--EXPECTF--
+UPDATE users SET `users`.`active` = ?
+WHERE `confirm`.`key` = ?
+    AND `users`.`email` = ?
+Array
+(
+    [0] => 1
+    [1] => 123
+    [2] => 123
+)
+UPDATE users SET [users].[active] = ?
+WHERE [confirm].[key] = ?
+    AND [users].[email] = ?
+Array
+(
+    [0] => 1
+    [1] => 123
+    [2] => 123
+)


### PR DESCRIPTION
Addresses #147 

The where function would try to detect whether the condition is a valid identifier or not, and if it is add the appropriate comparison operator, `=` or `is null` or `in (..)` however the regex failed to match some values. 

Instead of detecting if its a valid identifier or not, I inversed the condition to check if there's already a comparison being made, if not then we create our new sql condition with the `=` `is null` or `in`

Another implementation could be that we just check for the presence of a positional placeholder in it (aka `strpos('?')`)

Thoughts? @cbornhoft @lichtner @StefanYohansson @Kent55 


EDIT: Changed the implementation to check for positional parameter placeholder `?` or named parameter `:param` instead of trying to check for operator since that wouldnt turn too well with operators such as `LIKE` or regex operator `~`. If noone has objections about this we can merge it.

However what this means is that `?` and `:` are not accepted as valid column names, howerver we can live with that.